### PR TITLE
Update RedHat master.cf to RHEL7

### DIFF
--- a/templates/master.cf.redhat.erb
+++ b/templates/master.cf.redhat.erb
@@ -69,26 +69,56 @@ scache	  unix	-	-	<%= @jail %>	-	1	scache
 # maildrop. See the Postfix MAILDROP_README file for details.
 # Also specify in main.cf: maildrop_destination_recipient_limit=1
 #
-maildrop  unix  -       n       n       -       -       pipe
-  flags=DRhu user=<%= @mail_user %> argv=/usr/local/bin/maildrop -d ${recipient}
+#maildrop  unix  -       n       n       -       -       pipe
+#  flags=DRhu user=<%= @mail_user %> argv=/usr/local/bin/maildrop -d ${recipient}
 #
-# The Cyrus deliver program has changed incompatibly, multiple times.
+# ====================================================================
 #
-old-cyrus unix  -       n       n       -       -       pipe
-  flags=R user=cyrus argv=/usr/lib/cyrus-imapd/deliver -e -m ${extension} ${user}
+# Recent Cyrus versions can use the existing "lmtp" master.cf entry.
+#
+# Specify in cyrus.conf:
+#   lmtp    cmd="lmtpd -a" listen="localhost:lmtp" proto=tcp4
+#
+# Specify in main.cf one or more of the following:
+#  mailbox_transport = lmtp:inet:localhost
+#  virtual_transport = lmtp:inet:localhost
+#
+# ====================================================================
+#
 # Cyrus 2.1.5 (Amos Gouaux)
 # Also specify in main.cf: cyrus_destination_recipient_limit=1
-cyrus     unix  -       n       n       -       -       pipe
-  user=cyrus argv=/usr/lib/cyrus-imapd/deliver -e -r ${sender} -m ${extension} ${user}
+#
+#cyrus     unix  -       n       n       -       -       pipe
+#  user=cyrus argv=/usr/lib/cyrus-imapd/deliver -e -r ${sender} -m ${extension} ${user}
+#
+# ====================================================================
+#
+# Old example of delivery via Cyrus.
+#
+#old-cyrus unix  -       n       n       -       -       pipe
+#  flags=R user=cyrus argv=/usr/lib/cyrus-imapd/deliver -e -m ${extension} ${user}
+#
+# ====================================================================
 #
 # See the Postfix UUCP_README file for configuration details.
 #
-uucp      unix  -       n       n       -       -       pipe
-  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#uucp      unix  -       n       n       -       -       pipe
+#  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#
+# ====================================================================
 #
 # Other external delivery methods.
 #
-ifmail    unix  -       n       n       -       -       pipe
-  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
-bsmtp     unix  -       n       n       -       -       pipe
-  flags=Fq. user=foo argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
+#ifmail    unix  -       n       n       -       -       pipe
+#  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+#
+#bsmtp     unix  -       n       n       -       -       pipe
+#  flags=Fq. user=bsmtp argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
+#
+#scalemail-backend unix -       n       n       -       2       pipe
+#  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store
+#  ${nexthop} ${user} ${extension}
+#
+#mailman   unix  -       n       n       -       -       pipe
+#  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
+#  ${nexthop} ${user}

--- a/templates/master.cf.redhat.erb
+++ b/templates/master.cf.redhat.erb
@@ -29,7 +29,7 @@ smtp      inet  n       -       <%= @jail %>       -       -       smtpd
 #  -o smtpd_tls_wrappermode=yes
 #  -o smtpd_sasl_auth_enable=yes
 #  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
-#628      inet  n       -       n       -       -       qmqpd
+#628       inet  n       -       n       -       -       qmqpd
 pickup    fifo  n       -       <%= @jail %>       60      1       pickup
 cleanup   unix  n       -       <%= @jail %>       -       0       cleanup
 qmgr      fifo  n       -       n       300     1       qmgr
@@ -55,7 +55,7 @@ local     unix  -       n       n       -       -       local
 virtual   unix  -       n       n       -       -       virtual
 lmtp      unix  -       -       <%= @jail %>       -       -       lmtp
 anvil     unix  -       -       <%= @jail %>       -       1       anvil
-scache	  unix	-	-	<%= @jail %>	-	1	scache
+scache    unix  -       -       <%= @jail %>       -       1       scache
 #
 # ====================================================================
 # Interfaces to non-Postfix software. Be sure to examine the manual

--- a/templates/master.cf.redhat.erb
+++ b/templates/master.cf.redhat.erb
@@ -58,9 +58,7 @@ verify    unix  -       -       <%= @jail %>       -       1       verify
 flush     unix  n       -       <%= @jail %>       1000?   0       flush
 proxymap  unix  -       -       n       -       -       proxymap
 smtp      unix  -       -       <%= @jail %>       -       -       smtp
-# When relaying mail as backup MX, disable fallback_relay to avoid MX loops
 relay     unix  -       -       <%= @jail %>       -       -       smtp
-	-o fallback_relay=
 #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
 showq     unix  n       -       <%= @jail %>       -       -       showq
 error     unix  -       -       <%= @jail %>       -       -       error

--- a/templates/master.cf.redhat.erb
+++ b/templates/master.cf.redhat.erb
@@ -45,10 +45,10 @@ smtp      inet  n       -       <%= @jail %>       -       -       smtpd
 #  -o smtpd_recipient_restrictions=permit_sasl_authenticated,reject
 #  -o milter_macro_daemon_name=ORIGINATING
 #628       inet  n       -       n       -       -       qmqpd
-pickup    fifo  n       -       <%= @jail %>       60      1       pickup
+pickup    unix  n       -       <%= @jail %>       60      1       pickup
 cleanup   unix  n       -       <%= @jail %>       -       0       cleanup
-qmgr      fifo  n       -       n       300     1       qmgr
-#qmgr     fifo  n       -       n       300     1       oqmgr
+qmgr      unix  n       -       n       300     1       qmgr
+#qmgr     unix  n       -       n       300     1       oqmgr
 tlsmgr    unix  -       -       <%= @jail %>       1000?   1       tlsmgr
 rewrite   unix  -       -       <%= @jail %>       -       -       trivial-rewrite
 bounce    unix  -       -       <%= @jail %>       -       0       <%= @master_bounce_command %>

--- a/templates/master.cf.redhat.erb
+++ b/templates/master.cf.redhat.erb
@@ -57,6 +57,7 @@ trace     unix  -       -       <%= @jail %>       -       0       bounce
 verify    unix  -       -       <%= @jail %>       -       1       verify
 flush     unix  n       -       <%= @jail %>       1000?   0       flush
 proxymap  unix  -       -       n       -       -       proxymap
+proxywrite unix -       -       n       -       1       proxymap
 smtp      unix  -       -       <%= @jail %>       -       -       smtp
 relay     unix  -       -       <%= @jail %>       -       -       smtp
 #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5

--- a/templates/master.cf.redhat.erb
+++ b/templates/master.cf.redhat.erb
@@ -20,15 +20,30 @@ smtp      inet  n       -       <%= @jail %>       -       -       smtpd
 <% if @master_smtps -%>
 <%= @master_smtps %>
 <% end -%>
-#smtp      inet  n       -       n       -       -       smtpd
+#smtp      inet  n       -       n       -       1       postscreen
+#smtpd     pass  -       -       n       -       -       smtpd
+#dnsblog   unix  -       -       n       -       0       dnsblog
+#tlsproxy  unix  -       -       n       -       0       tlsproxy
 #submission inet n       -       n       -       -       smtpd
-#  -o smtpd_enforce_tls=yes
+#  -o syslog_name=postfix/submission
+#  -o smtpd_tls_security_level=encrypt
 #  -o smtpd_sasl_auth_enable=yes
-#  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
+#  -o smtpd_reject_unlisted_recipient=no
+#  -o smtpd_client_restrictions=$mua_client_restrictions
+#  -o smtpd_helo_restrictions=$mua_helo_restrictions
+#  -o smtpd_sender_restrictions=$mua_sender_restrictions
+#  -o smtpd_recipient_restrictions=permit_sasl_authenticated,reject
+#  -o milter_macro_daemon_name=ORIGINATING
 #smtps     inet  n       -       n       -       -       smtpd
+#  -o syslog_name=postfix/smtps
 #  -o smtpd_tls_wrappermode=yes
 #  -o smtpd_sasl_auth_enable=yes
-#  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
+#  -o smtpd_reject_unlisted_recipient=no
+#  -o smtpd_client_restrictions=$mua_client_restrictions
+#  -o smtpd_helo_restrictions=$mua_helo_restrictions
+#  -o smtpd_sender_restrictions=$mua_sender_restrictions
+#  -o smtpd_recipient_restrictions=permit_sasl_authenticated,reject
+#  -o milter_macro_daemon_name=ORIGINATING
 #628       inet  n       -       n       -       -       qmqpd
 pickup    fifo  n       -       <%= @jail %>       60      1       pickup
 cleanup   unix  n       -       <%= @jail %>       -       0       cleanup


### PR DESCRIPTION
As mentioned in #219 there are a number of places where the puppet-pushed master.cf differs from the one provided by a default install.

Using #219 as a starting point I've gone through and made a series of small commits so that it's fairly obvious what changes are being made.  The idea here is to modernize the puppet config, and reduce the differences experienced during an initial puppetization of a pristine host.