### PR TITLE
Declare CentOS 9 Support, Install s-nail on 9

### DIFF
--- a/data/osfamily/RedHat/9.yaml
+++ b/data/osfamily/RedHat/9.yaml
@@ -1,0 +1,3 @@
+---
+
+postfix::params::mailx_package: 's-nail'

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,8 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/acceptance/postfix_spec.rb
+++ b/spec/acceptance/postfix_spec.rb
@@ -41,7 +41,7 @@ describe 'postfix class' do
       it { is_expected.to be_running }
     end
 
-    describe file('/etc/aliases') do
+    describe file('/etc/aliases', '/usr/bin/mailx') do
       it { is_expected.to exist }
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
* Add CentOS 9 to metadata.yml
* Install s-nail on CentOS/RHEL 9 as mailx package does not exist.

Note on Fedora mailx is still fine as mailx or s-nail are available as alternatives for mailx command.
