### PR TITLE
Add switches for simple domain masquerade

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ A Boolean defining whether the puppet module should manage the mailx package. Se
 
 Default: true.
 
+##### `masquerade_classes`
+An array defining the masquerade_classes to use.
+Default: Undefined.
+Example: ['envelope_sender', 'envelope_recipient', 'header_sender', 'header_recipient']
+
+##### `masquerade_domains`
+An array defining the masquerade_domains to use.
+The order of elements matters here, so be aware of how you define the elements.
+Default: Undefined.
+Example: ['foo.example.com', 'example.com']
+
+##### `masquerade_exceptions`
+An array defining the masquerade_exceptions to use.
+Default: Undefined.
+Example: ['root']
+
 ##### `mastercf_source`
 A string defining the location of a skeleton master.cf file to be used.
 Default: Undefined.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,12 @@
 #
 # [*manage_mailx*]        - (boolean) Whether to manage mailx package.
 #
+# [*masquerade_classes*]  - (array)
+#
+# [*masquerade_domains*]  - (array)
+#
+# [*masquerade_exceptions*] - (array)
+#
 # [*mastercf_source*]     - (string)
 #
 # [*mastercf_content*]    - (string)
@@ -127,6 +133,9 @@ class postfix (
   Boolean                         $manage_conffiles    = true,
   Boolean                         $manage_mailname     = true,
   Boolean                         $manage_mailx        = true,
+  Optional[Array[String[1]]]      $masquerade_classes  = undef,
+  Optional[Array[String[1]]]      $masquerade_domains  = undef,
+  Optional[Array[String[1]]]      $masquerade_exceptions = undef,
   Optional[String]                $mastercf_source     = undef,
   Optional[String]                $mastercf_content    = undef,
   Optional[String]                $mastercf_template   = undef,

--- a/manifests/mta.pp
+++ b/manifests/mta.pp
@@ -15,6 +15,9 @@
 #                     directly without a relay.
 # [*mydestination*] - (string)
 # [*mynetworks*]    - (string)
+# [*masquerade_classes*]    - (array)
+# [*masquerade_domains*]    - (array)
+# [*masquerade_exceptions*] - (array)
 #
 # === Examples
 #
@@ -29,12 +32,18 @@ class postfix::mta (
   Optional[Pattern[/^\S+(?:,\s*\S+)*$/]]                $mydestination = undef,
   Optional[Pattern[/^(?:\S+?(?:(?:,\s+)|(?:\s+))?)*$/]] $mynetworks    = undef,
   Optional[Pattern[/^\S+$/]]                            $relayhost     = undef,
+  Optional[Array[String[1]]]                            $masquerade_classes  = undef,
+  Optional[Array[String[1]]]                            $masquerade_domains  = undef,
+  Optional[Array[String[1]]]                            $masquerade_exceptions = undef,
 ) {
   include postfix
 
   $_mydestination = pick($mydestination, $postfix::mydestination)
   $_mynetworks = pick($mynetworks, $postfix::mynetworks)
   $_relayhost = pick($relayhost, $postfix::relayhost)
+  $_masquerade_classes    = pick_default($masquerade_classes, $postfix::masquerade_classes)
+  $_masquerade_domains    = pick_default($masquerade_domains, $postfix::masquerade_domains)
+  $_masquerade_exceptions = pick_default($masquerade_exceptions, $postfix::masquerade_exceptions)
 
   # If direct is specified then relayhost should be blank
   if ($_relayhost == 'direct') {
@@ -54,6 +63,16 @@ class postfix::mta (
     'mynetworks':          value => $_mynetworks;
     'virtual_alias_maps':  value => "hash:${postfix::confdir}/virtual";
     'transport_maps':      value => "hash:${postfix::confdir}/transport";
+  }
+
+  if ! $_masquerade_classes.empty() {
+    postfix::config { 'masquerade_classes': value => join($_masquerade_classes, ' ') }
+  }
+  if ! $_masquerade_domains.empty() {
+    postfix::config { 'masquerade_domains': value => join($_masquerade_domains, ' ') }
+  }
+  if ! $_masquerade_exceptions.empty() {
+    postfix::config { 'masquerade_exceptions': value => join($_masquerade_exceptions, ' ') }
   }
 
   postfix::hash { "${postfix::confdir}/virtual":

--- a/manifests/satellite.pp
+++ b/manifests/satellite.pp
@@ -12,6 +12,9 @@
 # [*mydestination*] - (string)
 # [*mynetworks*] - (string)
 # [*relayhost*] - (string)
+# [*masquerade_classes*]    - (array)
+# [*masquerade_domains*]    - (array)
+# [*masquerade_exceptions*] - (array)
 #
 # === Examples
 #
@@ -26,6 +29,9 @@ class postfix::satellite (
   $mydestination = undef,
   $mynetworks    = undef,
   $relayhost     = undef,
+  $masquerade_classes    = undef,
+  $masquerade_domains    = undef,
+  $masquerade_exceptions = undef,
 ) {
   include postfix
 
@@ -34,11 +40,17 @@ class postfix::satellite (
   $_mydestination = pick($mydestination, $postfix::mydestination)
   $_mynetworks = pick($mynetworks, $postfix::mynetworks)
   $_relayhost = pick($relayhost, $postfix::relayhost)
+  $_masquerade_classes    = pick_default($masquerade_classes, $postfix::masquerade_classes)
+  $_masquerade_domains    = pick_default($masquerade_domains, $postfix::masquerade_domains)
+  $_masquerade_exceptions = pick_default($masquerade_exceptions, $postfix::masquerade_exceptions)
 
   class { 'postfix::mta':
-    mydestination => $_mydestination,
-    mynetworks    => $_mynetworks,
-    relayhost     => $_relayhost,
+    mydestination         => $_mydestination,
+    mynetworks            => $_mynetworks,
+    relayhost             => $_relayhost,
+    masquerade_classes    => $masquerade_classes,
+    masquerade_domains    => $masquerade_domains,
+    masquerade_exceptions => $masquerade_exceptions,
   }
 
   postfix::virtual { "@${postfix::myorigin}":

--- a/spec/classes/postfix_mta_spec.rb
+++ b/spec/classes/postfix_mta_spec.rb
@@ -8,6 +8,9 @@ describe 'postfix::mta' do
       mydestination => 'bar',
       mynetworks    => '127.0.0.1/8, [::1]/128 ![::2]/128',
       relayhost     => 'foo',
+      masquerade_classes => ['envelope_sender'],
+      masquerade_domains => ['host.example.com',  'example.com'],
+      masquerade_exceptions => ['root'],
     }"
   end
 
@@ -21,6 +24,9 @@ describe 'postfix::mta' do
       it { is_expected.to contain_postfix__config('mydestination').with_value('bar') }
       it { is_expected.to contain_postfix__config('mynetworks').with_value('127.0.0.1/8, [::1]/128 ![::2]/128') }
       it { is_expected.to contain_postfix__config('relayhost').with_value('foo') }
+      it { is_expected.to contain_postfix__config('masquerade_classes').with_value('envelope_sender') }
+      it { is_expected.to contain_postfix__config('masquerade_domains').with_value('host.example.com example.com') }
+      it { is_expected.to contain_postfix__config('masquerade_exceptions').with_value('root') }
 
       context "when mydestination => 'blank'" do
         let :pre_condition do


### PR DESCRIPTION
#### Pull Request (PR) description
When setting up simple mail routing, it is handy to have a quick way to setup domain masquerade to convert messages for DKIM or SPF acceptance.

#### This Pull Request (PR) fixes the following issues
None