### PR TITLE
Native support for storing `bind_pw` in hiera; `ldap_options` is now more flexible.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,8 @@
 #
 # [*ldap_host*]           - (string)
 #
+# [*ldap_bind_pw*]        - (string)
+#
 # [*ldap_options*]        - (string)
 #
 # [*mail_user*]           - (string) The mail user
@@ -126,7 +128,8 @@ class postfix (
   Boolean                         $ldap                = false,
   Optional[String]                $ldap_base           = undef,
   Optional[String]                $ldap_host           = undef,
-  Optional[String]                $ldap_options        = undef,
+  Optional[String]                $ldap_bind_pw        = undef,
+  Optional[Variant[String,Array[String]]]  $ldap_options        = undef,
   String                          $mail_user           = 'vmail',       # postfix_mail_user
   Boolean                         $mailman             = false,
   String                          $maincf_source       = "puppet:///modules/${module_name}/main.cf",

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -19,7 +19,7 @@ class postfix::ldap {
   assert_type(Optional[String], $postfix::ldap_bind_pw)
   assert_type(Optional[Variant[String,Array[String]]], $postfix::ldap_options)
 
-  if $facts['os']['family'] in [ 'Debian', 'RedHat' ] {
+  if $facts['os']['family'] in ['Debian','RedHat'] {
     package { 'postfix-ldap':
       before  => File["${postfix::confdir}/ldap-aliases.cf"],
     }

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -16,9 +16,10 @@
 class postfix::ldap {
   assert_type(String, $postfix::ldap_base)
   assert_type(String, $postfix::ldap_host)
-  assert_type(String, $postfix::ldap_options)
+  assert_type(Optional[String], $postfix::ldap_bind_pw)
+  assert_type(Optional[Variant[String,Array[String]]], $postfix::ldap_options)
 
-  if $facts['os']['family'] == 'Debian' {
+  if $facts['os']['family'] in [ 'Debian', 'RedHat' ] {
     package { 'postfix-ldap':
       before  => File["${postfix::confdir}/ldap-aliases.cf"],
     }
@@ -27,6 +28,8 @@ class postfix::ldap {
   if ! $postfix::ldap_base {
     fail 'Missing $postfix::ldap_base !'
   }
+
+  $ldap_bind_pw = $postfix::ldap_bind_pw
 
   $ldap_host = $postfix::ldap_host ? {
     undef   => 'localhost',

--- a/templates/postfix-ldap-aliases.cf.erb
+++ b/templates/postfix-ldap-aliases.cf.erb
@@ -3,4 +3,11 @@ server_host = <%= @ldap_host %>
 <% if @ldap_base -%>
 search_base = <%= @ldap_base %>
 <% end -%>
-<%= @ldap_options %>
+<%
+    options = [ @ldap_options ].flatten
+    if @ldap_bind_pw
+        options.append('bind_pw = ' + @ldap_bind_pw )
+    end
+    if options -%>
+<%= options.sort.join("\n") %>
+<% end -%>


### PR DESCRIPTION
There was no intrinsic way to store an encrypted bind password in heira, so added '$postfix::ldap_bind_pw'.

Converted '$postfix::ldap_options' to be optional or a string or an array of strings.

Modified the ldap-aliases.cf template so that ldap_options can be optional / a string / an array of strings, and then rendered in alphabetical order.

