### PR TITLE
Fix typos errors in postfix::satellite from PR 326

### DIFF
--- a/manifests/mta.pp
+++ b/manifests/mta.pp
@@ -41,9 +41,9 @@ class postfix::mta (
   $_mydestination = pick($mydestination, $postfix::mydestination)
   $_mynetworks = pick($mynetworks, $postfix::mynetworks)
   $_relayhost = pick($relayhost, $postfix::relayhost)
-  $_masquerade_classes    = pick_default($masquerade_classes, $postfix::masquerade_classes)
-  $_masquerade_domains    = pick_default($masquerade_domains, $postfix::masquerade_domains)
-  $_masquerade_exceptions = pick_default($masquerade_exceptions, $postfix::masquerade_exceptions)
+  $_masquerade_classes    = $masquerade_classes.lest || { $postfix::masquerade_classes }
+  $_masquerade_domains    = $masquerade_domains.lest || { $postfix::masquerade_domains }
+  $_masquerade_exceptions = $masquerade_exceptions.lest || { $postfix::masquerade_exceptions }
 
   # If direct is specified then relayhost should be blank
   if ($_relayhost == 'direct') {

--- a/manifests/satellite.pp
+++ b/manifests/satellite.pp
@@ -40,9 +40,9 @@ class postfix::satellite (
   $_mydestination = pick($mydestination, $postfix::mydestination)
   $_mynetworks = pick($mynetworks, $postfix::mynetworks)
   $_relayhost = pick($relayhost, $postfix::relayhost)
-  $_masquerade_classes    = pick_default($masquerade_classes, $postfix::masquerade_classes)
-  $_masquerade_domains    = pick_default($masquerade_domains, $postfix::masquerade_domains)
-  $_masquerade_exceptions = pick_default($masquerade_exceptions, $postfix::masquerade_exceptions)
+  $_masquerade_classes    = $masquerade_classes.lest || { $postfix::masquerade_classes }
+  $_masquerade_domains    = $masquerade_domains.lest || { $postfix::masquerade_domains }
+  $_masquerade_exceptions = $masquerade_exceptions.lest || { $postfix::masquerade_exceptions }
 
   class { 'postfix::mta':
     mydestination         => $_mydestination,

--- a/manifests/satellite.pp
+++ b/manifests/satellite.pp
@@ -48,9 +48,9 @@ class postfix::satellite (
     mydestination         => $_mydestination,
     mynetworks            => $_mynetworks,
     relayhost             => $_relayhost,
-    masquerade_classes    => $masquerade_classes,
-    masquerade_domains    => $masquerade_domains,
-    masquerade_exceptions => $masquerade_exceptions,
+    masquerade_classes    => $_masquerade_classes,
+    masquerade_domains    => $_masquerade_domains,
+    masquerade_exceptions => $_masquerade_exceptions,
   }
 
   postfix::virtual { "@${postfix::myorigin}":


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes variable typos that has been added with Pull Request #326.

This is just cosmetic since this values are also pick_default inside `postfix::mta` and does result to the same catalog on the systems even when it here results to pass `undef` to `postfix::mta`.

Note for this Change these Lines, that are not used but now will with this PR: https://github.com/voxpupuli/puppet-postfix/blob/f3978930db8055a54bf75118b11a0d5e8dcfd1d7/manifests/satellite.pp#L43-L45

#### This Pull Request (PR) fixes the following issues
None
