### PR TITLE
Remove camptocamp/puppet-augeas dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,5 @@ fixtures:
   repositories:
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
     concat: https://github.com/voxpupuli/puppet-alternatives.git
-    augeas: https://github.com/camptocamp/puppet-augeas.git
     mailalias_core: https://github.com/puppetlabs/puppetlabs-mailalias_core.git
     augeas_core: https://github.com/puppetlabs/puppetlabs-augeas_core.git

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 * FreeBSD
 
 ## Dependencies
-  - [puppetlabs-augeas_core-augeas 1.0.0+](https://github.com/puppetlabs/puppetlabs-augeas_core)
+  - [puppetlabs-augeas_core 1.0.0+](https://github.com/puppetlabs/puppetlabs-augeas_core)
   - [puppet-alternatives 2.0.0+](https://github.com/voxpupuli/puppet-alternatives)
   - [puppetlabs-mailalias_core 1.0.5+](https://github.com/puppetlabs/puppetlabs-mailalias_core)
   - [puppetlabs-stdlib 4.13.0+](https://github.com/puppetlabs/puppetlabs-stdlib)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 * FreeBSD
 
 ## Dependencies
-  - [camptocamp-augeas 1.0.0+](https://github.com/camptocamp/puppet-augeas)
+  - [puppetlabs-augeas_core-augeas 1.0.0+](https://github.com/puppetlabs/puppetlabs-augeas_core)
   - [puppet-alternatives 2.0.0+](https://github.com/voxpupuli/puppet-alternatives)
   - [puppetlabs-mailalias_core 1.0.5+](https://github.com/puppetlabs/puppetlabs-mailalias_core)
   - [puppetlabs-stdlib 4.13.0+](https://github.com/puppetlabs/puppetlabs-stdlib)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 * FreeBSD
 
 ## Dependencies
-  - [puppetlabs-augeas_core 1.0.0+](https://github.com/puppetlabs/puppetlabs-augeas_core)
   - [puppet-alternatives 2.0.0+](https://github.com/voxpupuli/puppet-alternatives)
   - [puppetlabs-mailalias_core 1.0.5+](https://github.com/puppetlabs/puppetlabs-mailalias_core)
   - [puppetlabs-stdlib 4.13.0+](https://github.com/puppetlabs/puppetlabs-stdlib)

--- a/metadata.json
+++ b/metadata.json
@@ -13,10 +13,6 @@
       "version_requirement": ">= 4.13.0 < 10.0.0"
     },
     {
-      "name": "puppetlabs/augeas_core",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
-    },
-    {
       "name": "puppet/alternatives",
       "version_requirement": ">= 2.0.0 < 6.0.0"
     },

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
       "version_requirement": ">= 4.13.0 < 10.0.0"
     },
     {
-      "name": "camptocamp/augeas",
+      "name": "puppetlabs/augeas_core",
       "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -530,9 +530,6 @@ describe 'postfix' do
 
       context 'when specifying satellite' do # rubocop:disable RSpec/MultipleMemoizedHelpers
         let(:params) { { satellite: true, mydestination: '1.2.3.4', relayhost: '2.3.4.5' } }
-        let :pre_condition do
-          "class { 'augeas': }"
-        end
 
         it 'compiles with expected resources' do
           is_expected.to compile.with_all_deps

--- a/spec/defines/postfix_transport_spec.rb
+++ b/spec/defines/postfix_transport_spec.rb
@@ -7,7 +7,6 @@ describe 'postfix::transport' do
 
   let :pre_condition do
     <<-EOT
-    class { '::augeas': }
     class { '::postfix': }
     EOT
   end

--- a/spec/defines/postfix_virtual_spec.rb
+++ b/spec/defines/postfix_virtual_spec.rb
@@ -7,7 +7,6 @@ describe 'postfix::virtual' do
 
   let :pre_condition do
     <<-EOT
-    class { '::augeas': }
     class { '::postfix': }
     EOT
   end


### PR DESCRIPTION
#### Pull Request (PR) description
camptocamp/puppet-augeas depends on puppetlabs/augeas_core while itself being out of support.  This removes references to the camptocamp module and goes straight to using augeas_core.

This shouldn't introduce any new dependency that wasn't inherently already there.

#### This Pull Request (PR) fixes the following issues
#353 mentions puppet8 in the title but this module fix in the description.  Out of an abundance of caution of not stepping on someone else's issue, I'm not marking this as 'fixes'. 