### PR TITLE
Drop mailalias_core dependency from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,10 +19,6 @@
     {
       "name": "puppet/alternatives",
       "version_requirement": ">= 2.0.0 < 6.0.0"
-    },
-    {
-      "name": "puppetlabs/mailalias_core",
-      "version_requirement": ">= 1.0.5 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This is a core dependency, they are vendored in the Puppet AIO packages and should not be listed in the metadata.json.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
