### PR TITLE
DOC: Remove camptocamp/augeas reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 * FreeBSD
 
 ## Dependencies
-  - [camptocamp-augeas 1.0.0+](https://github.com/camptocamp/puppet-augeas)
   - [puppet-alternatives 2.0.0+](https://github.com/voxpupuli/puppet-alternatives)
   - [puppetlabs-mailalias_core 1.0.5+](https://github.com/puppetlabs/puppetlabs-mailalias_core)
   - [puppetlabs-stdlib 4.13.0+](https://github.com/puppetlabs/puppetlabs-stdlib)


### PR DESCRIPTION
#### Pull Request (PR) description

Trivial documentation fix. 4.4.0 removed the dependency in metadata.json but retained it in the README. Let's keep the two in sync.

#### This Pull Request (PR) fixes the following issues

n/a