### PR TITLE
Extend canonical augeas lens regex

### DIFF
--- a/lib/augeas/lenses/postfix_canonical.aug
+++ b/lib/augeas/lenses/postfix_canonical.aug
@@ -32,7 +32,7 @@ let space_or_eol (sep:regexp) (default:string) =
   del (space_or_eol_re? . sep . space_or_eol_re?) default 
 
 (* View: word *)
-let word = store /[A-Za-z0-9@\*.+-]+/
+let word = store /[A-Za-z0-9@\*.+-_!$&'=?^`{|}~]+/
 
 (* View: comma *)
 let comma = space_or_eol "," ", "

--- a/lib/augeas/lenses/test_postfix_canonical.aug
+++ b/lib/augeas/lenses/test_postfix_canonical.aug
@@ -10,6 +10,7 @@ let conf = "# a comment
 user@domain.com @domain
 @otherdomain  @otherotherdomain
 someuser  Full.Some.User
+anotheruser  another_user+mail=address@domain
 "
 
 (* Test: Postfix_Canonical.lns *)
@@ -23,4 +24,7 @@ test Postfix_Canonical.lns get conf =
   }
   { "pattern" = "someuser"
     { "destination" = "Full.Some.User" }
+  }
+  { "pattern" = "anotheruser"
+    { "destination" = "another_user+mail=address@domain" }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add support for a wider range of e-mail addresses.

From [RFC 3696](https://datatracker.ietf.org/doc/html/rfc3696) (informational only but referring to [RFC 2821](https://datatracker.ietf.org/doc/html/rfc2821) and [RFC 2822](https://datatracker.ietf.org/doc/html/rfc2822)):
```
   Without quotes, local-parts may consist of any combination of
   alphabetic characters, digits, or any of the special characters

      ! # $ % & ' * + - / = ?  ^ _ ` . { | } ~

   period (".") may also appear, but may not be used to start or end the
   local part, nor may two or more consecutive periods appear.  Stated
   differently, any ASCII graphic (printing) character other than the
   at-sign ("@"), backslash, double quote, comma, or square brackets may
   appear without quoting.  If any of that list of excluded characters
   are to appear, they must be quoted.
```
Note that due to the format of canonical(5) we can't include addresses starting with `#` despite being valid e-mail addresses as they are treated as comments. Apart from that exclusion, the defined regexp is a compromise that includes a bit more than allowed (in particular includes addresses with multiple `@` and doesn't check for `.` not being at the start or at the end of the local part, but as discussed at #345 this should be fine.

#### This Pull Request (PR) fixes the following issues

Fixes #345 