### PR TITLE
WIP: Allow initial content for virtual and transport if mta is true

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -124,6 +124,10 @@ The following parameters are available in the `postfix` class:
 * [`masquerade_domains`](#-postfix--masquerade_domains)
 * [`masquerade_exceptions`](#-postfix--masquerade_exceptions)
 * [`mta`](#-postfix--mta)
+* [`mta_virtual_content`](#-postfix--mta_virtual_content)
+* [`mta_virtual_source`](#-postfix--mta_virtual_source)
+* [`mta_transport_content`](#-postfix--mta_transport_content)
+* [`mta_transport_source`](#-postfix--mta_transport_source)
 * [`mydestination`](#-postfix--mydestination)
 * [`mynetworks`](#-postfix--mynetworks)
 * [`myorigin`](#-postfix--myorigin)
@@ -476,6 +480,42 @@ A Boolean to define whether to configure Postfix as a mail transfer agent.
 This option is mutually exclusive with the satellite Boolean.
 
 Default value: `false`
+
+##### <a name="-postfix--mta_virtual_content"></a>`mta_virtual_content`
+
+Data type: `Optional[String]`
+
+A free form string that defines the contents of the virtual file. Only used if mta is true.
+This parameter is mutually exclusive with mta_virtual_source.
+
+Default value: `undef`
+
+##### <a name="-postfix--mta_virtual_source"></a>`mta_virtual_source`
+
+Data type: `Optional[String]`
+
+A String whose value is a location for the source file to be used for the virtual file.
+Only used if mta is true. This parameter is mutually exclusive with mta_virtual_content.
+
+Default value: `undef`
+
+##### <a name="-postfix--mta_transport_content"></a>`mta_transport_content`
+
+Data type: `Optional[String]`
+
+A free form string that defines the contents of the transport file. Only used if mta is true.
+This parameter is mutually exclusive with mta_transport_source.
+
+Default value: `undef`
+
+##### <a name="-postfix--mta_transport_source"></a>`mta_transport_source`
+
+Data type: `Optional[String]`
+
+A String whose value is a location for the source file to be used for the transport file.
+Only used if mta is true. This parameter is mutually exclusive with mta_transport_content.
+
+Default value: `undef`
 
 ##### <a name="-postfix--mydestination"></a>`mydestination`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -187,6 +187,22 @@
 #   A Boolean to define whether to configure Postfix as a mail transfer agent.
 #   This option is mutually exclusive with the satellite Boolean.
 #
+# @param mta_virtual_content
+#   A free form string that defines the contents of the virtual file. Only used if mta is true.
+#   This parameter is mutually exclusive with mta_virtual_source.
+#
+# @param mta_virtual_source
+#   A String whose value is a location for the source file to be used for the virtual file.
+#   Only used if mta is true. This parameter is mutually exclusive with mta_virtual_content.
+#
+# @param mta_transport_content
+#   A free form string that defines the contents of the transport file. Only used if mta is true.
+#   This parameter is mutually exclusive with mta_transport_source.
+#
+# @param mta_transport_source
+#   A String whose value is a location for the source file to be used for the transport file.
+#   Only used if mta is true. This parameter is mutually exclusive with mta_transport_content.
+#
 # @param mydestination
 #   A string to define the mydestination parameter in main.cf (postconf(5)).
 #   Example: `example.com, foo.example.com`.
@@ -286,6 +302,10 @@ class postfix (
   Optional[Array[String[1]]]           $masquerade_domains    = undef,
   Optional[Array[String[1]]]           $masquerade_exceptions = undef,
   Boolean                              $mta                   = false,
+  Optional[String]                     $mta_virtual_content   = undef,
+  Optional[String]                     $mta_virtual_source    = undef,
+  Optional[String]                     $mta_transport_content = undef,
+  Optional[String]                     $mta_transport_source  = undef,
   String                               $mydestination         = '$myhostname, localhost.$mydomain, localhost',  # postfix_mydestination
   String                               $mynetworks            = '127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128', # postfix_mynetworks
   String                               $myorigin              = $facts['networking']['fqdn'],
@@ -369,6 +389,14 @@ class postfix (
 
   if $ldap {
     include postfix::ldap
+  }
+
+  if $mta_virtual_content and $mta_virtual_source {
+    fail('You must provide either \'mta_virtual_content\' or \'mta_virtual_source\', not both.')
+  }
+
+  if $mta_transport_content and $mta_transport_source {
+    fail('You must provide either \'mta_transport_content\' or \'mta_transport_source\', not both.')
   }
 
   if $mta {

--- a/manifests/mta.pp
+++ b/manifests/mta.pp
@@ -51,10 +51,14 @@ class postfix::mta (
   }
 
   postfix::hash { "${postfix::confdir}/virtual":
-    ensure => 'present',
+    ensure  => 'present',
+    content => $postfix::mta_virtual_content,
+    source  => $postfix::mta_virtual_source,
   }
 
   postfix::hash { "${postfix::confdir}/transport":
-    ensure => 'present',
+    ensure  => 'present',
+    content => $postfix::mta_transport_content,
+    source  => $postfix::mta_transport_source,
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
I have over 1,500 virtual aliases and if I add them to virtual a la the postfix::virtual defined type puppet runs take a very long time. Also, when I remove an item I want it to actually be removed from my postfix configs too without having to leave it in my data with an ensure absent.

This change allows a user to provide initial seed content to the virtual and transport hashes that are created if you set mta to true. This way, current functionality is maintained, but if you opt to you can build your own content for virtual or transport outside of the module and bring it in.
