### PR TITLE
postfix-ldap required for ldap lookup type on RHEL8+

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -100,6 +100,7 @@ The following parameters are available in the `postfix` class:
 * [`ldap_base`](#-postfix--ldap_base)
 * [`ldap_host`](#-postfix--ldap_host)
 * [`ldap_options`](#-postfix--ldap_options)
+* [`ldap_packages`](#-postfix--ldap_packages)
 * [`lookup_table_type`](#-postfix--lookup_table_type)
 * [`mail_user`](#-postfix--mail_user)
 * [`mailman`](#-postfix--mailman)
@@ -256,6 +257,14 @@ A free form string that can define any LDAP options to be passed through (ldap_t
 Example: `start_tls = yes`.
 
 Default value: `undef`
+
+##### <a name="-postfix--ldap_packages"></a>`ldap_packages`
+
+Data type: `Array[String[1]]`
+
+An array of package names to install for LDAP support if $ldap is true.
+
+Default value: `[]`
 
 ##### <a name="-postfix--lookup_table_type"></a>`lookup_table_type`
 

--- a/data/osfamily/Debian.yaml
+++ b/data/osfamily/Debian.yaml
@@ -1,4 +1,5 @@
 ---
 postfix::params::mailx_package: 'bsd-mailx'
 postfix::params::master_os_template: 'postfix/master.cf.debian.erb'
+postfix::ldap_packages: ['postfix-ldap']
 ...

--- a/data/osfamily/RedHat/9.yaml
+++ b/data/osfamily/RedHat/9.yaml
@@ -1,3 +1,4 @@
 ---
 
 postfix::params::mailx_package: 's-nail'
+postfix::ldap_packages: ['postfix-ldap']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,9 @@
 #   A free form string that can define any LDAP options to be passed through (ldap_table(5)).
 #   Example: `start_tls = yes`.
 #
+# @param ldap_packages
+#   An array of package names to install for LDAP support if $ldap is true.
+#
 # @param lookup_table_type
 #   Table format type as described in http://www.postfix.org/DATABASE_README.html#types.
 #   Type has to be supported by system, see "postconf -m" for supported types.
@@ -262,6 +265,7 @@ class postfix (
   Optional[String]                     $ldap_base             = undef,
   Optional[String]                     $ldap_host             = undef,
   Optional[String]                     $ldap_options          = undef,
+  Array[String[1]]                     $ldap_packages         = [],
   String                               $lookup_table_type     = 'hash',
   String                               $mail_user             = 'vmail',       # postfix_mail_user
   Boolean                              $mailman               = false,

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -8,9 +8,10 @@ class postfix::ldap {
   assert_type(String, $postfix::ldap_host)
   assert_type(String, $postfix::ldap_options)
 
-  if $facts['os']['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' or ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] >= '8') {
     package { 'postfix-ldap':
-      before  => File["${postfix::confdir}/ldap-aliases.cf"],
+      ensure => installed,
+      before => File["${postfix::confdir}/ldap-aliases.cf"],
     }
   }
 

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -8,11 +8,9 @@ class postfix::ldap {
   assert_type(String, $postfix::ldap_host)
   assert_type(String, $postfix::ldap_options)
 
-  if $facts['os']['family'] == 'Debian' or ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] >= '8') {
-    package { 'postfix-ldap':
-      ensure => installed,
-      before => File["${postfix::confdir}/ldap-aliases.cf"],
-    }
+  package { $postfix::ldap_packages:
+    ensure => installed,
+    before => File["${postfix::confdir}/ldap-aliases.cf"],
   }
 
   if ! $postfix::ldap_base {


### PR DESCRIPTION
#### Pull Request (PR) description
Install postfix-ldap package when ldap=true on RHEL8+

#### This Pull Request (PR) fixes the following issues
Fixes #397