### PR TITLE
rm duplicated spec example

### DIFF
--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -317,18 +317,6 @@ describe 'postfix' do
         end
       end
 
-      context 'when specifying a custom mastercf_template' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-        let(:params) do
-          {
-            mastercf_template: 'testy',
-          }
-        end
-
-        it 'does stuff' do
-          skip 'need to write this still'
-        end
-      end
-
       context 'when specifying a custom mastercf_source and mastercf_content' do # rubocop:disable RSpec/MultipleMemoizedHelpers
         let(:params) do
           {


### PR DESCRIPTION
Resolves this GHA warning:

    postfix on debian-11-x86_64 when specifying a custom mastercf_template does stuff

    Skipped: need to write this still

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
