### PR TITLE
feat: make mta alternative configurable

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -125,6 +125,7 @@ The following parameters are available in the `postfix` class:
 * [`masquerade_classes`](#-postfix--masquerade_classes)
 * [`masquerade_domains`](#-postfix--masquerade_domains)
 * [`masquerade_exceptions`](#-postfix--masquerade_exceptions)
+* [`mta_bin_path`](#-postfix--mta_bin_path)
 * [`mta`](#-postfix--mta)
 * [`mydestination`](#-postfix--mydestination)
 * [`mynetworks`](#-postfix--mynetworks)
@@ -485,6 +486,15 @@ Data type: `Optional[Array[String[1]]]`
 An array defining the masquerade_exceptions to use. This optional list of user names that are not
 subjected to address masquerading, even when their addresses match $masquerade_domains.
 Example: `['root']`
+
+Default value: `undef`
+
+##### <a name="-postfix--mta_bin_path"></a>`mta_bin_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+An optional path for mta 'alternative'.
+Example: `'/usr/sbin/sendmail.postfix'`
 
 Default value: `undef`
 

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -3,4 +3,5 @@ postfix::params::aliasesseltype: 'etc_aliases_t'
 postfix::params::seltype: 'postfix_etc_t'
 postfix::params::restart_cmd: '/bin/systemctl reload postfix'
 postfix::params::master_os_template: 'postfix/master.cf.redhat.erb'
+postfix::mta_bin_path: '/usr/sbin/sendmail.postfix'
 ...

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,6 +191,10 @@
 #   subjected to address masquerading, even when their addresses match $masquerade_domains.
 #   Example: `['root']`
 #
+# @param mta_bin_path
+#   An optional path for mta 'alternative'.
+#   Example: `'/usr/sbin/sendmail.postfix'`
+#
 # @param mta
 #   A Boolean to define whether to configure Postfix as a mail transfer agent.
 #   This option is mutually exclusive with the satellite Boolean.
@@ -295,6 +299,7 @@ class postfix (
   Optional[Array[String[1]]]           $masquerade_classes    = undef,
   Optional[Array[String[1]]]           $masquerade_domains    = undef,
   Optional[Array[String[1]]]           $masquerade_exceptions = undef,
+  Optional[Stdlib::Absolutepath]       $mta_bin_path          = undef,
   Boolean                              $mta                   = false,
   String                               $mydestination         = '$myhostname, localhost.$mydomain, localhost',  # postfix_mydestination
   String                               $mynetworks            = '127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128', # postfix_mynetworks

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -29,9 +29,9 @@ class postfix::service {
       require     => Service['postfix'],
     }
   }
-  if $facts['os']['family'] == 'RedHat' {
+  if $postfix::mta_bin_path {
     alternatives { 'mta':
-      path    => '/usr/sbin/sendmail.postfix',
+      path    => $postfix::mta_bin_path,
       require => Service['postfix'],
     }
   }


### PR DESCRIPTION
Currently, resource is created unconditionally on Redhat family, but recent fedora packages moved binary to `/usr/bin/sendmail.postfix`. This change makes it backwards compatible, but allows override the path if required.