### PR TITLE
feat: add hiera data for RHEL10

### DIFF
--- a/data/osfamily/RedHat/10.yaml
+++ b/data/osfamily/RedHat/10.yaml
@@ -1,0 +1,5 @@
+---
+postfix::alias_maps: 'lmdb:/etc/aliases'
+postfix::ldap_packages: ['postfix-ldap']
+postfix::lookup_table_type: 'lmdb'
+postfix::params::mailx_package: 's-nail'


### PR DESCRIPTION
adding 10 to metadata.json would require updating testing pipelines, I think, but this will benefit early adopters