### PR TITLE
Set a default value for `postfix::params::master_os_template`

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,5 +2,6 @@
 postfix::params::aliasesseltype: ~
 postfix::params::seltype: ~
 postfix::params::mailx_package: 'mailx'
+postfix::params::master_os_template: "postfix/master.cf.default.erb"
 postfix::params::restart_cmd: '/etc/init.d/postfix reload'
 ...

--- a/templates/master.cf.default.erb
+++ b/templates/master.cf.default.erb
@@ -1,0 +1,178 @@
+#
+# Postfix master process configuration file.  For details on the format
+# of the file, see the master(5) manual page (command: "man 5 master" or
+# on-line: http://www.postfix.org/master.5.html).
+#
+# Do not forget to execute "postfix reload" after editing this file.
+#
+# ==========================================================================
+# service type  private unpriv  chroot  wakeup  maxproc command + args
+#               (yes)   (yes)   (yes)   (never) (100)
+# ==========================================================================
+<% if @master_smtp -%>
+<%= @master_smtp %>
+<% elsif @smtp_listen == 'all' -%>
+smtp      inet  n       -       n       -       -       smtpd
+<% else -%>
+  <%- (@smtp_listen.is_a?(Array) ? @smtp_listen : @smtp_listen.split(' ')).each do |listen_address| -%>
+<%= listen_address %>:smtp      inet  n       -       <%= @jail %>       -       -       smtpd
+  <%- end -%>
+<% end -%>
+<% if @master_submission -%>
+<%= @master_submission %>
+<% end -%>
+<% if @master_smtps -%>
+<%= @master_smtps %>
+<% end -%>
+#smtp      inet  n       -       n       -       -       smtpd
+#amavis    unix  -       -       n       -       4       smtp
+#  -o smtp_data_done_timeout=1200
+#  -o smtp_send_xforward_command=yes
+#  -o disable_dns_lookups=yes
+#  -o max_use=20
+#smtp      inet  n       -       n       -       1       postscreen
+#smtpd     pass  -       -       n       -       -       smtpd
+#dnsblog   unix  -       -       n       -       0       dnsblog
+#tlsproxy  unix  -       -       n       -       0       tlsproxy
+#submission inet n       -       n       -       -       smtpd
+#   -o syslog_name=postfix/submission
+#   -o smtpd_tls_security_level=encrypt
+#   -o smtpd_sasl_auth_enable=yes
+#   -o smtpd_reject_unlisted_recipient=no
+#   -o smtpd_client_restrictions=$mua_client_restrictions
+#   -o smtpd_helo_restrictions=$mua_helo_restrictions
+#   -o smtpd_sender_restrictions=$mua_sender_restrictions
+#   -o smtpd_recipient_restrictions=
+#   -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#   -o milter_macro_daemon_name=ORIGINATING
+#smtps     inet  n       -       n       -       -       smtpd
+#    -o syslog_name=postfix/smtps
+#    -o smtpd_tls_wrappermode=yes
+#    -o content_filter=smtp:[127.0.0.1]:10024
+#    -o smtpd_sasl_auth_enable=yes
+#    -o smtpd_reject_unlisted_recipient=no
+#    -o smtpd_client_restrictions=$mua_client_restrictions
+#    -o smtpd_helo_restrictions=$mua_helo_restrictions
+#    -o smtpd_sender_restrictions=$mua_sender_restrictions
+#    -o smtpd_recipient_restrictions=
+#    -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#    -o milter_macro_daemon_name=ORIGINATING
+#628       inet  n       -       n       -       -       qmqpd
+pickup    fifo  n       -       n       60      1       pickup
+cleanup   unix  n       -       n       -       0       cleanup
+qmgr      fifo  n       -       n       300     1       qmgr
+#qmgr     fifo  n       -       n       300     1       oqmgr
+#tlsmgr    unix  -       -       n       1000?   1       tlsmgr
+rewrite   unix  -       -       n       -       -       trivial-rewrite
+bounce    unix  -       -       n       -       0       <%= @master_bounce_command %>
+defer     unix  -       -       n       -       0       <%= @master_defer_command %>
+trace     unix  -       -       n       -       0       bounce
+verify    unix  -       -       n       -       1       verify
+flush     unix  n       -       n       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+proxywrite unix -       -       n       -       1       proxymap
+smtp      unix  -       -       n       -       -       smtp
+relay     unix  -       -       n       -       -       smtp
+#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+showq     unix  n       -       n       -       -       showq
+error     unix  -       -       n       -       -       error
+retry     unix  -       -       n       -       -       error
+discard   unix  -       -       n       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       n       -       -       lmtp
+anvil     unix  -       -       n       -       1       anvil
+#localhost:10025 inet   n       -       n       -       -       smtpd
+#  -o content_filter=
+#  -o smtpd_delay_reject=no
+#  -o smtpd_client_restrictions=permit_mynetworks,reject
+#  -o smtpd_helo_restrictions=
+#  -o smtpd_sender_restrictions=
+#  -o smtpd_recipient_restrictions=permit_mynetworks,reject
+#  -o smtpd_data_restrictions=reject_unauth_pipelining
+#  -o smtpd_end_of_data_restrictions=
+#  -o smtpd_restriction_classes=
+#  -o mynetworks=127.0.0.0/8
+#  -o smtpd_error_sleep_time=0
+#  -o smtpd_soft_error_limit=1001
+#  -o smtpd_hard_error_limit=1000
+#  -o smtpd_client_connection_count_limit=0
+#  -o smtpd_client_connection_rate_limit=0
+#  -o receive_override_options=no_unknown_recipient_checks,no_header_body_checks,no_address_mappings
+#  -o local_header_rewrite_clients=
+#  -o local_recipient_maps=
+#  -o relay_recipient_maps=
+scache    unix  -       -       n       -       1       scache
+#
+# ====================================================================
+# Interfaces to non-Postfix software. Be sure to examine the manual
+# pages of the non-Postfix software to find out what options it wants.
+#
+# Many of the following services use the Postfix pipe(8) delivery
+# agent.  See the pipe(8) man page for information about ${recipient}
+# and other message envelope options.
+# ====================================================================
+#
+# maildrop. See the Postfix MAILDROP_README file for details.
+# Also specify in main.cf: maildrop_destination_recipient_limit=1
+#
+#maildrop  unix  -       n       n       -       -       pipe
+#  flags=DRhu user=<%= @mail_user %> argv=/usr/local/bin/maildrop -d ${recipient}
+#
+# ====================================================================
+#
+# Recent Cyrus versions can use the existing "lmtp" master.cf entry.
+#
+# Specify in cyrus.conf:
+#   lmtp    cmd="lmtpd -a" listen="localhost:lmtp" proto=tcp4
+#
+# Specify in main.cf one or more of the following:
+#  mailbox_transport = lmtp:inet:localhost
+#  virtual_transport = lmtp:inet:localhost
+#
+# ====================================================================
+#
+# Cyrus 2.1.5 (Amos Gouaux)
+# Also specify in main.cf: cyrus_destination_recipient_limit=1
+#
+#cyrus     unix  -       n       n       -       -       pipe
+#  user=cyrus argv=/usr/lib/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
+#
+# ====================================================================
+#
+# Old example of delivery via Cyrus.
+#
+#old-cyrus unix  -       n       n       -       -       pipe
+#  flags=R user=cyrus argv=/cyrus/bin/deliver -e -m ${extension} ${user}
+#
+# ====================================================================
+#
+# See the Postfix UUCP_README file for configuration details.
+#
+#uucp      unix  -       n       n       -       -       pipe
+#  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#
+# ====================================================================
+#
+# Other external delivery methods.
+#
+#ifmail    unix  -       n       n       -       -       pipe
+#  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+#
+#bsmtp     unix  -       n       n       -       -       pipe
+#  flags=Fq. user=bsmtp argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
+#
+#scalemail-backend unix -       n       n       -       2       pipe
+#  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store
+#  ${nexthop} ${user} ${extension}
+#
+#mailman   unix  -       n       n       -       -       pipe
+#  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
+#  ${nexthop} ${user}
+#
+#procmail  unix  -       n       n       -       -       pipe
+#  flags=R user=nobody argv=/usr/bin/procmail -t -m /etc/procmailrc ${sender} ${recipient}
+#
+#dovecot   unix  -       n       n       -       -       pipe
+#  flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}
+#


### PR DESCRIPTION
#### Pull Request (PR) description

Even if a specific OS is not supported according to `metadata.json`, Puppet should not fail with
`Class[Postfix::Params]: expects a value for parameter 'master_os_template'`

Instead it should use a Default-Template for `master.cf`.

The here provided Template is the restored Suse-Template deleted in 8cf7f1ef2f469c21ce10053a6b2a7aebc167d047.

#### This Pull Request (PR) fixes the following issues

Fixes #418