### PR TITLE
New `canonicals` parameter of `postfix::canonical` types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -148,6 +148,7 @@ The following parameters are available in the `postfix` class:
 * [`use_schleuder`](#-postfix--use_schleuder)
 * [`use_sympa`](#-postfix--use_sympa)
 * [`virtuals`](#-postfix--virtuals)
+* [`canonicals`](#-postfix--canonicals)
 
 ##### <a name="-postfix--alias_maps"></a>`alias_maps`
 
@@ -654,6 +655,14 @@ Default value: `false`
 Data type: `Hash`
 
 A hash of postfix::virtual resources
+
+Default value: `{}`
+
+##### <a name="-postfix--canonicals"></a>`canonicals`
+
+Data type: `Hash[String[1], Hash[String[1], Any]]`
+
+A hash of postfix::canonical resources
 
 Default value: `{}`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -260,6 +260,9 @@
 # @param virtuals
 #   A hash of postfix::virtual resources
 #
+# @param canonicals
+#   A hash of postfix::canonical resources
+#
 class postfix (
   String $alias_maps = 'hash:/etc/aliases',
   Integer $amavis_procs = 2,
@@ -318,6 +321,7 @@ class postfix (
   Variant[Integer[2, 3], Boolean] $use_schleuder = false, # postfix_use_schleuder
   Boolean $use_sympa = false, # postfix_use_sympa
   Hash $virtuals = {},
+  Hash[String[1], Hash[String[1], Any]] $canonicals = {},
 ) inherits postfix::params {
   if (
     ($mastercf_source and $mastercf_content) or
@@ -358,6 +362,12 @@ class postfix (
 
   $virtuals.each |$key, $value| {
     postfix::virtual { $key:
+      * => $value,
+    }
+  }
+
+  $canonicals.each |$key, $value| {
+    postfix::canonical { $key:
       * => $value,
     }
   }

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -756,6 +756,31 @@ describe 'postfix' do
         end
       end
 
+      context 'when canonicals hash is used' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+        let :pre_condition do
+          "postfix::hash{'/etc/postfix/sender_canonical': ensure => present }"
+        end
+        let(:params) do
+          {
+            canonicals: {
+              'root' => {
+                'destination' => 'root_special@example.org',
+                'file'        => '/etc/postfix/sender_canonical',
+              },
+              'adm' => {
+                'destination' => 'adm_special@example.org',
+                'file'        => '/etc/postfix/sender_canonical',
+              },
+            },
+          }
+        end
+
+        it 'updates the cannonical map' do
+          is_expected.to contain_postfix__canonical('root').with_destination('root_special@example.org')
+          is_expected.to contain_postfix__canonical('adm').with_file('/etc/postfix/sender_canonical')
+        end
+      end
+
       context 'when conffiles hash is used' do # rubocop:disable RSpec/MultipleMemoizedHelpers
         let(:params) do
           {


### PR DESCRIPTION
#### Pull Request (PR) description

New canonicals parameter can be used for easily defining `postfix::canonical` resources as a hash in hiera data.

e.g.

```yaml
postfix::canonicals:
  root:
    ensure: present
    destination: "root_%{facts.networking.hostname}@example.ch"
    file: 'etc/postfix/sender_canonical'
```

