### PR TITLE
Switch Default for Restart-Command to systemctl

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,5 +3,5 @@ postfix::params::aliasesseltype: ~
 postfix::params::seltype: ~
 postfix::params::mailx_package: 'mailx'
 postfix::params::master_os_template: "postfix/master.cf.default.erb"
-postfix::params::restart_cmd: '/etc/init.d/postfix reload'
+postfix::params::restart_cmd: '/usr/bin/systemctl reload postfix'
 ...

--- a/data/os/Alpine.yaml
+++ b/data/os/Alpine.yaml
@@ -1,2 +1,3 @@
 ---
 postfix::params::master_os_template: "postfix/master.cf.debian.erb"
+postfix::params::restart_cmd: '/etc/init.d/postfix reload'

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -1,7 +1,6 @@
 ---
 postfix::params::aliasesseltype: 'etc_aliases_t'
 postfix::params::seltype: 'postfix_etc_t'
-postfix::params::restart_cmd: '/bin/systemctl reload postfix'
 postfix::params::master_os_template: 'postfix/master.cf.redhat.erb'
 postfix::mta_bin_path: '/usr/sbin/sendmail.postfix'
 ...

--- a/data/osfamily/RedHat/6.yaml
+++ b/data/osfamily/RedHat/6.yaml
@@ -1,0 +1,5 @@
+---
+
+postfix::params::mailx_package: 's-nail'
+postfix::ldap_packages: ['postfix-ldap']
+postfix::params::restart_cmd: '/etc/init.d/postfix reload'

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -84,7 +84,7 @@ describe 'postfix' do
               ensure: 'running',
               enable: 'true',
               hasstatus: 'true',
-              restart: '/etc/init.d/postfix reload'
+              restart: '/usr/bin/systemctl reload postfix'
             )
           }
         end
@@ -111,7 +111,7 @@ describe 'postfix' do
                 ensure: 'running',
                 enable: 'true',
                 hasstatus: 'true',
-                restart: '/bin/systemctl reload postfix'
+                restart: '/usr/bin/systemctl reload postfix'
               )
             }
           end
@@ -124,7 +124,7 @@ describe 'postfix' do
                 ensure: 'running',
                 enable: 'true',
                 hasstatus: 'true',
-                restart: '/bin/systemctl reload postfix'
+                restart: '/usr/bin/systemctl reload postfix'
               )
             }
           end
@@ -151,7 +151,7 @@ describe 'postfix' do
               ensure: 'running',
               enable: 'true',
               hasstatus: 'true',
-              restart: '/bin/systemctl reload postfix'
+              restart: '/usr/bin/systemctl reload postfix'
             )
           }
         end
@@ -234,7 +234,7 @@ describe 'postfix' do
               ensure: 'running',
               enable: 'true',
               hasstatus: 'true',
-              restart: '/etc/init.d/postfix reload'
+              restart: '/usr/bin/systemctl reload postfix'
             )
           }
 


### PR DESCRIPTION
This superseeds https://github.com/voxpupuli/puppet-postfix/pull/443

Almost all Linux-Distributions now default to Systemd. So switch the Default for Restart-Command to `systemctl`.

  *  use `/usr/bin/systemctl` instead of `/bin/systemctl`, because with usr-Merge the former Dir is dead
  *  keep Alpine on `/etc/init.d`
